### PR TITLE
use of '-c' did limit search, not output

### DIFF
--- a/html/process.php
+++ b/html/process.php
@@ -130,7 +130,7 @@ function CompileCommand($mode) {
 		// sort the flows from all sources
 		$args .= $process_form['timesorted'] == 'checked' ? " -m" : '';
 		// list this number of flows
-		$args .= " -c " . $ListNOption[$process_form['listN']];
+		$args .= " -n " . $ListNOption[$process_form['listN']];
 	}
 
 	// process stat request


### PR DESCRIPTION
"Limit to X Flows" option in detail view does limit *search* to 20 flows by default, and doesn't allow searching more than 10000 flows, which is not much.
I suppose here the original intention was to limit output, not searching (which is selected elsewhere by date/time)