### PR TITLE
email notification: Date: field is required by rfcs

### DIFF
--- a/libexec/NfAlert.pm
+++ b/libexec/NfAlert.pm
@@ -43,7 +43,7 @@ use POSIX ":sys_wait_h";
 use POSIX 'strftime';
 use Mail::Header;
 use Mail::Internet;
-use Email::Date::Format qw(email_date);
+use Date::Format qw(time2str);
 
 use NfSen;
 use NfSenRRD;
@@ -834,11 +834,11 @@ sub GetAlertPluginCondition {
 } # End of GetAlertPluginCondition
 
 sub ExecuteAction {
-	my $alert		= shift;
+	my $alert	= shift;
 	my $alertref 	= shift;
 	my $alertstatus	= shift;
 	my $timeslot	= shift;
-	my $email_date = email_date;
+	my $email_date  = time2str('%a, %d %b %Y %H:%M:%S %z', time);
 
 	# send email 
 	if ( ($$alertref{'action_type'} & 1) > 0 ) {

--- a/libexec/NfAlert.pm
+++ b/libexec/NfAlert.pm
@@ -43,6 +43,7 @@ use POSIX ":sys_wait_h";
 use POSIX 'strftime';
 use Mail::Header;
 use Mail::Internet;
+use Email::Date::Format qw(email_date);
 
 use NfSen;
 use NfSenRRD;
@@ -837,6 +838,7 @@ sub ExecuteAction {
 	my $alertref 	= shift;
 	my $alertstatus	= shift;
 	my $timeslot	= shift;
+	my $email_date = email_date;
 
 	# send email 
 	if ( ($$alertref{'action_type'} & 1) > 0 ) {
@@ -845,6 +847,7 @@ sub ExecuteAction {
 		my @header = ( 	
 			"From: $NfConf::MAIL_FROM",
 			"To: $$alertref{'action_email'}",
+			"Date: $email_date",
 			"Subject: $$alertref{'action_subject'}" 
 		);
 

--- a/libexec/Notification.pm
+++ b/libexec/Notification.pm
@@ -42,7 +42,7 @@ use Sys::Syslog;
 
 use Mail::Header;
 use Mail::Internet;
-use Email::Date::Format qw(email_date);
+use Date::Format qw(time2str);
 
 # What we export
 
@@ -61,7 +61,7 @@ sub notify {
 	my $subject   = shift;
 	my $body_ref  = shift;
 	my $rcpt_to = $NfConf::RCPT_TO ;
-	my $email_date = email_date;
+	my $email_date = time2str('%a, %d %b %Y %H:%M:%S %z', time);
 	if ( scalar @_ == 1 ) {
 		$rcpt_to = shift;
 	}

--- a/libexec/Notification.pm
+++ b/libexec/Notification.pm
@@ -42,6 +42,7 @@ use Sys::Syslog;
 
 use Mail::Header;
 use Mail::Internet;
+use Email::Date::Format qw(email_date);
 
 # What we export
 
@@ -60,6 +61,7 @@ sub notify {
 	my $subject   = shift;
 	my $body_ref  = shift;
 	my $rcpt_to = $NfConf::RCPT_TO ;
+	my $email_date = email_date;
 	if ( scalar @_ == 1 ) {
 		$rcpt_to = shift;
 	}
@@ -69,6 +71,7 @@ sub notify {
 	my @mail_head = ( 	
 		"From: $NfConf::MAIL_FROM",
 		"To: $rcpt_to",
+		"Date: $email_date",
 		"Subject: $subject" 
 	);
 


### PR DESCRIPTION
RFC *22  :)  says: "The only required header fields are the origination **date** field and the originator address field(s). " E-mail send via notify() hasn't got this Header. This is simple fix via Email::Date::Format module.