### PR TITLE
PHP 8.2: ${var} string interpolation deprecated

### DIFF
--- a/html/details.php
+++ b/html/details.php
@@ -811,9 +811,9 @@ function DisplayDetails () {
 		$d_ext = $d == 1 ? '' : 's';
 		$h_ext = $h == 1 ? '' : 's';
 		if ( $d ) {
-			$expire = "$d day${d_ext} $h hour{$h_ext}";
+			$expire = "$d day{$d_ext} $h hour{$h_ext}";
 		} else {
-			$expire = "$h hour${h_ext}";
+			$expire = "$h hour{$h_ext}";
 		}
 	}
 

--- a/html/nfsenutil.php
+++ b/html/nfsenutil.php
@@ -341,7 +341,7 @@ function ScaleValue ( $val, $rateval ) {
 	if ( $scaled > 0 )
 		$str = sprintf("%5.1f %s%s", $scaled, $unit, $rate_label);
 	else
-		$str = "$value ${unit}${rate_label}";
+		$str = "$value {$unit}{$rate_label}";
 
 	return preg_replace("/^\s+/", "", $str);
 	
@@ -386,7 +386,7 @@ function ScaleBytes ( $value, $rateval, $bs ) {
 	if ( $scaled > 0 )
 		$str = sprintf("%5.1f %s%s%s", $scaled, $unit, $Bit_Byte, $rate_label);
 	else
-		$str = "$value ${unit}${Bit_Byte}${rate_label}";
+		$str = "$value {$unit}{$Bit_Byte}{$rate_label}";
 
 	return preg_replace("/^\s+/", "", $str);
 	

--- a/html/overview.php
+++ b/html/overview.php
@@ -54,13 +54,13 @@ function DisplayGraphs ($type) {
 	}
 
 	$profileswitch = "$profilegroup/$profile";
-	print "<a href='$self?tab=2&win=day&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file=${type}-day' width='669' height='281' border='0'></a>\n";
+	print "<a href='$self?tab=2&win=day&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file={$type}-day' width='669' height='281' border='0'></a>\n";
 	print "<br>";
-	print "<a href='$self?tab=2&win=week&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file=${type}-week' width='669' height='281' border='0'></a>\n";
+	print "<a href='$self?tab=2&win=week&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file={$type}-week' width='669' height='281' border='0'></a>\n";
 	print "<br>";
-	print "<a href='$self?tab=2&win=month&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file=${type}-month' width='669' height='281' border='0'></a>\n";
+	print "<a href='$self?tab=2&win=month&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file={$type}-month' width='669' height='281' border='0'></a>\n";
 	print "<br>";
-	print "<a href='$self?tab=2&win=year&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file=${type}-year' width='669' height='281' border='0'></a>\n";
+	print "<a href='$self?tab=2&win=year&type=$type'> <IMG src='pic.php?profileswitch=$profileswitch&amp;file={$type}-year' width='669' height='281' border='0'></a>\n";
 	print "<br>";
 
 } # End of DisplayHistory


### PR DESCRIPTION
Dollar sign ($) outside of the curly braces

https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated